### PR TITLE
PKG-14080: align blas anaconda.yaml packages with active Distro DB

### DIFF
--- a/anaconda.yaml
+++ b/anaconda.yaml
@@ -8,8 +8,3 @@ upstream_sources:
       to_pattern: \1
     packages:
       - blas
-      - blas-devel
-      - libblas
-      - libcblas
-      - liblapack
-      - liblapacke


### PR DESCRIPTION
## Summary
DDB Group 3 — yaml listed conda packages not present as active in Distro DB.

## Changes
- `anaconda.yaml`: keep only `blas` under `upstream_sources[].packages`.
- Remove `blas-devel`, `libblas`, `libcblas`, `liblapack`, `liblapacke` (inactive in DDB).

## Ticket
PKG-14080

Made with [Cursor](https://cursor.com)